### PR TITLE
Fix #1 Implement CRC16 for SAM3X8E microprocessor

### DIFF
--- a/ModbusMaster.cpp
+++ b/ModbusMaster.cpp
@@ -737,7 +737,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   u16CRC = 0xFFFF;
   for (i = 0; i < u8ModbusADUSize; i++)
   {
-    u16CRC = _crc16_update(u16CRC, u8ModbusADU[i]);
+    u16CRC = crc16_update(u16CRC, u8ModbusADU[i]);
   }
   u8ModbusADU[u8ModbusADUSize++] = lowByte(u16CRC);
   u8ModbusADU[u8ModbusADUSize++] = highByte(u16CRC);
@@ -845,7 +845,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
     u16CRC = 0xFFFF;
     for (i = 0; i < (u8ModbusADUSize - 2); i++)
     {
-      u16CRC = _crc16_update(u16CRC, u8ModbusADU[i]);
+      u16CRC = crc16_update(u16CRC, u8ModbusADU[i]);
     }
     
     // verify CRC

--- a/ModbusMaster.h
+++ b/ModbusMaster.h
@@ -80,7 +80,7 @@ Macro to generate 32-bit integer from (2) 16-bit words.
 
 /* _____PROJECT INCLUDES_____________________________________________________ */
 // functions to calculate Modbus Application Data Unit CRC
-#include <util/crc16.h>
+#include "util/crc16.h"
 
 
 /* _____CLASS DEFINITIONS____________________________________________________ */

--- a/util/crc16.h
+++ b/util/crc16.h
@@ -1,0 +1,84 @@
+/* Copyright (c) 2002, 2003, 2004  Marek Michalkiewicz
+   Copyright (c) 2005, 2007 Joerg Wunsch
+   Copyright (c) 2013 Dave Hylands
+   Copyright (c) 2013 Frederic Nadeau
+   Copyright (c) 2015 Doc Walker
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+#ifndef _UTIL_CRC16_H_
+#define _UTIL_CRC16_H_
+
+/** \file */
+/** \defgroup util_crc <util/crc16.h>: CRC Computations
+    \code#include <util/crc16.h>\endcode
+
+    This header file provides functions for calculating
+    cyclic redundancy checks (CRC) using common polynomials.
+    Modified by Doc Walker to be processor-independent (removed inline
+    assembler to allow it to compile on SAM3X8E processors).
+
+    \par References:
+
+    \par
+
+    Jack Crenshaw's "Implementing CRCs" article in the January 1992 isue of \e
+    Embedded \e Systems \e Programming. This may be difficult to find, but it
+    explains CRC's in very clear and concise terms. Well worth the effort to
+    obtain a copy.
+
+*/
+
+/** \ingroup util_crc
+    Processor-independent CRC-16 calculation.
+
+    Polynomial: x^16 + x^15 + x^2 + 1 (0xa001)<br>
+    Initial value: 0xffff
+
+    This CRC is normally used in disk-drive controllers.
+
+    \endcode */
+
+static uint16_t crc16_update(uint16_t crc, uint8_t a)
+{
+  int i;
+
+  crc ^= a;
+  for (i = 0; i < 8; ++i)
+  {
+    if (crc & 1)
+      crc = (crc >> 1) ^ 0xA001;
+    else
+      crc = (crc >> 1);
+  }
+
+  return crc;
+}
+
+#endif /* _UTIL_CRC16_H_ */


### PR DESCRIPTION
- renamed _crc16_update to crc16_update to minimize confusion with AVR
  function in util/crc16.h
- added C version of crc16 and removed extraneous version of crc16 functions