### PR TITLE
Fix #2 Work around HardwareSerial for SAM3 micro

### DIFF
--- a/ModbusMaster.cpp
+++ b/ModbusMaster.cpp
@@ -33,7 +33,13 @@ Arduino library for communicating with Modbus slaves over RS232/485 (via RTU pro
 
 
 /* _____GLOBAL VARIABLES_____________________________________________________ */
-HardwareSerial MBSerial = Serial; ///< Pointer to Serial class object
+#ifdef __AVR__
+  HardwareSerial *MBSerial = &Serial; ///< Pointer to Serial class object
+#endif
+
+#ifdef __arm__
+  UARTClass *MBSerial = &Serial; ///< Pointer to Serial class object
+#endif
 
 
 /* _____PUBLIC FUNCTIONS_____________________________________________________ */
@@ -118,29 +124,29 @@ void ModbusMaster::begin(uint16_t u16BaudRate)
   {
 #if defined(UBRR1H)
     case 1:
-      MBSerial = Serial1;
+      MBSerial = &Serial1;
       break;
 #endif
       
 #if defined(UBRR2H)
     case 2:
-      MBSerial = Serial2;
+      MBSerial = &Serial2;
       break;
 #endif
       
 #if defined(UBRR3H)
     case 3:
-      MBSerial = Serial3;
+      MBSerial = &Serial3;
       break;
 #endif
       
     case 0:
     default:
-      MBSerial = Serial;
+      MBSerial = &Serial;
       break;
   }
   
-  MBSerial.begin(u16BaudRate);
+  MBSerial->begin(u16BaudRate);
 #if __MODBUSMASTER_DEBUG__
   pinMode(4, OUTPUT);
   pinMode(5, OUTPUT);
@@ -747,25 +753,25 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   for (i = 0; i < u8ModbusADUSize; i++)
   {
 #if defined(ARDUINO) && ARDUINO >= 100
-    MBSerial.write(u8ModbusADU[i]);
+    MBSerial->write(u8ModbusADU[i]);
 #else
-    MBSerial.print(u8ModbusADU[i], BYTE);
+    MBSerial->print(u8ModbusADU[i], BYTE);
 #endif
   }
   
   u8ModbusADUSize = 0;
-  MBSerial.flush();
+  MBSerial->flush();
   
   // loop until we run out of time or bytes, or an error occurs
   u32StartTime = millis();
   while (u8BytesLeft && !u8MBStatus)
   {
-    if (MBSerial.available())
+    if (MBSerial->available())
     {
 #if __MODBUSMASTER_DEBUG__
       digitalWrite(4, true);
 #endif
-      u8ModbusADU[u8ModbusADUSize++] = MBSerial.read();
+      u8ModbusADU[u8ModbusADUSize++] = MBSerial->read();
       u8BytesLeft--;
 #if __MODBUSMASTER_DEBUG__
       digitalWrite(4, false);


### PR DESCRIPTION
- add #ifdefs to check for presence of AVR or ARM chipset (use HardwareSerial
  for AVR and UARTClass for ARM)
- change MBSerial to pointer and update all references to use -> notation
  instead of . notation