### PR TITLE
Added preTransmission() and postTransmission(). Fixes #33

### DIFF
--- a/ModbusMaster.cpp
+++ b/ModbusMaster.cpp
@@ -188,8 +188,8 @@ void ModbusMaster::idle(void (*idle)())
 /**
 Set pre-transmission callback function.
 
-This function gets called just before a modbus message is sent over serial.
-Typical usage of this callback is to enable an RS485 transcieiver's
+This function gets called just before a Modbus message is sent over serial.
+Typical usage of this callback is to enable an RS485 transceiver's
 Driver Enable pin, and optionally disable its Receiver Enable pin.
 
 @see ModbusMaster::postTransmission()
@@ -202,12 +202,12 @@ void ModbusMaster::preTransmission(void (*preTransmission)())
 /**
 Set post-transmission callback function.
 
-This function gets called after a modbus message has finished sending
+This function gets called after a Modbus message has finished sending
 (i.e. after all data has been physically transmitted onto the serial
 bus).
 
-Typical usage of this callback is to enable an RS485 transcieiver's
-Received Enable pin, and disable its Driver Enable pin.
+Typical usage of this callback is to enable an RS485 transceiver's
+Receiver Enable pin, and disable its Driver Enable pin.
 
 @see ModbusMaster::postTransmission()
 */
@@ -705,7 +705,10 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   while (_serial->read() != -1);
 
   // transmit request
-  if (_preTransmission) _preTransmission();
+  if (_preTransmission)
+  {
+    _preTransmission();
+  }
   for (i = 0; i < u8ModbusADUSize; i++)
   {
 #if defined(ARDUINO) && ARDUINO >= 100
@@ -717,7 +720,10 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   
   u8ModbusADUSize = 0;
   _serial->flush();    // flush transmit buffer
-  if (_postTransmission) _postTransmission();
+  if (_postTransmission)
+  {
+    _postTransmission();
+  }
   
   // loop until we run out of time or bytes, or an error occurs
   u32StartTime = millis();

--- a/ModbusMaster.h
+++ b/ModbusMaster.h
@@ -45,7 +45,7 @@ Set to 1 to enable debugging features within class:
   - pin 5 cycles for each millisecond timeout during the Modbus response
 */
 #define __MODBUSMASTER_DEBUG__ (1)
-
+ 
 
 /* _____STANDARD INCLUDES____________________________________________________ */
 // include types & constants of Wiring core API
@@ -80,8 +80,10 @@ class ModbusMaster
     
     void begin();
     void begin(uint16_t);
-    void idle(void (*)());
-    
+    void idle(void (*)()); 
+    void preTransmission(void (*)());
+    void postTransmission(void (*)());
+   
     // Modbus exception codes
     /**
     Modbus protocol illegal function exception.
@@ -263,6 +265,10 @@ class ModbusMaster
     
     // idle callback function; gets called during idle time between TX and RX
     void (*_idle)();
+    // preTransmission callback function; gets called before writing a modbus message
+    void (*_preTransmission)();
+    // postTransmission callback function; gets after a modbus message has been sent
+    void (*_postTransmission)();
 };
 #endif
 

--- a/ModbusMaster.h
+++ b/ModbusMaster.h
@@ -45,7 +45,6 @@ Set to 1 to enable debugging features within class:
   - pin 5 cycles for each millisecond timeout during the Modbus response
 */
 #define __MODBUSMASTER_DEBUG__ (1)
- 
 
 /* _____STANDARD INCLUDES____________________________________________________ */
 // include types & constants of Wiring core API
@@ -261,9 +260,9 @@ class ModbusMaster
     
     // idle callback function; gets called during idle time between TX and RX
     void (*_idle)();
-    // preTransmission callback function; gets called before writing a modbus message
+    // preTransmission callback function; gets called before writing a Modbus message
     void (*_preTransmission)();
-    // postTransmission callback function; gets after a modbus message has been sent
+    // postTransmission callback function; gets called after a Modbus message has been sent
     void (*_postTransmission)();
 };
 #endif


### PR DESCRIPTION
This is a suggested API change to address dealing with RS-485 transceivers in half duplex mode (Issue #33).

I'm not married to this particular way of solving it, but it's tested to work on my end.
