### PR TITLE
Add email address to CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+reported by contacting the project owner at 4-20ma@wvfans.net. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
<!----------------------------------------------------------------------------
Please make sure you've read and understood our contributing guidelines;
https://github.com/4-20ma/ModbusMaster/blob/master/CONTRIBUTING.md

Provide the following information for all issues. Replace [brackets] and placeholder text with your responses.
(QUESTIONS, BUG REPORTS, FEATURE REQUESTS).
-->
### Description
Add missing email address to code of conduct document

### Issues Resolved
Resolves #56 

### Check List

General

- [x] Code follows coding style defined in STYLE.md
- [ ] Doxygen comments are included inline with code
- [x] No unnecessary whitespace; check with `git diff --check` before committing.

The following have been modified to reflect new features, if warranted

- [ ] README.md
- [ ] keywords.txt (use tabs as whitespace separators)
- [ ] library.properties
- [ ] examples/ - update or create new ones, as warranted

The following have **NOT** been modified

- [x] doc/ - will be updated upon versioned release
- [x] .ruby-gemset
- [x] .ruby-version
- [x] COPYING
- [x] Gemfile
- [x] HISTORY.md - will be updated upon versioned release
- [x] VERSION - will be updated upon versioned release

