### PR TITLE
Use relative path to examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,13 @@ install:
   - pip install -U platformio
 
 before_script:
+  - echo Environment:
   - env
   - echo $HOME
   - echo $TRAVIS_BUILD_DIR
   - ls -al $PWD
+  - echo Versions:
+  - python --version && pip --version && platformio --version
 
 script:
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_script:
   - echo $HOME
   - echo $TRAVIS_BUILD_DIR
   - ls -al $PWD
-  - platformio --version
 
 script:
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ install:
   - pip install -U platformio
 
 before_script:
-  - echo 'Environment:'
+  - #------------------------------------------------------------- environment
   - env
   - echo $HOME
   - echo $TRAVIS_BUILD_DIR
   - ls -al $PWD
-  - echo 'Versions:'
+  - #---------------------------------------------------------------- versions
   - python --version && pip --version && platformio --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ install:
   - pip install -U platformio
 
 before_script:
-  - #------------------------------------------------------------- environment
+  - echo --------------------------------------------------------- environment
   - env
   - echo $HOME
   - echo $TRAVIS_BUILD_DIR
   - ls -al $PWD
-  - #---------------------------------------------------------------- versions
+  - echo ------------------------------------------------------------ versions
   - python --version && pip --version && platformio --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,11 @@ install:
   - pip install -U platformio
 
 before_script:
-  - echo --------------------------------------------------------- environment
   - env
   - echo $HOME
   - echo $TRAVIS_BUILD_DIR
   - ls -al $PWD
-  - echo ------------------------------------------------------------ versions
-  - python --version && pip --version && platformio --version
+  - platformio --version
 
 script:
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ install:
   - pip install -U platformio
 
 before_script:
-  - echo Environment:
+  - echo 'Environment:'
   - env
   - echo $HOME
   - echo $TRAVIS_BUILD_DIR
   - ls -al $PWD
-  - echo Versions:
+  - echo 'Versions:'
   - python --version && pip --version && platformio --version
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------- settings
 FIND          := find
-DIR           := $(PWD)/examples
+DIR           := examples
 CRITERIA      := \( -name "*.ino" -o -name "*.pde" \)
 EACH_EXAMPLE  := $(FIND) $(DIR) $(CRITERIA) -exec
 BUILD         := platformio ci


### PR DESCRIPTION
<!----------------------------------------------------------------------------
Please make sure you've read and understood our contributing guidelines;
https://github.com/4-20ma/ModbusMaster/blob/master/CONTRIBUTING.md

Provide the following information for all issues. Replace [brackets] and placeholder text with your responses.
(QUESTIONS, BUG REPORTS, FEATURE REQUESTS).
-->
### Description
Changes `Makefile` to use relative path to examples instead of absolute

### Issues Resolved
N/A

### Check List

General

- [x] Code follows coding style defined in STYLE.md
- [ ] Doxygen comments are included inline with code
- [x] No unnecessary whitespace; check with `git diff --check` before committing.

The following have been modified to reflect new features, if warranted

- [ ] README.md
- [ ] keywords.txt (use tabs as whitespace separators)
- [ ] library.properties
- [ ] examples/ - update or create new ones, as warranted

The following have **NOT** been modified

- [x] doc/ - will be updated upon versioned release
- [x] .ruby-gemset
- [x] .ruby-version
- [x] CHANGELOG.md - will be updated upon versioned release (HISTORY.md is deprecated)
- [x] Gemfile
- [x] LICENSE
- [x] VERSION - will be updated upon versioned release
