### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The library contains a few sketches that demonstrate use of the `ModbusMaster` l
 
 */
 
-#include <ModbusMaster.h>
+# include <ModbusMaster.h>
 
 
 // instantiate ModbusMaster object


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
