### PR TITLE
use std::function<void()> instead of global callbacks

### DIFF
--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -178,7 +178,7 @@ serial ports, etc. is permitted within callback function.
 
 @see ModbusMaster::ModbusMasterTransaction()
 */
-void ModbusMaster::idle(void (*idle)())
+void ModbusMaster::idle(service_fn_t idle)
 {
   _idle = idle;
 }
@@ -193,7 +193,7 @@ Driver Enable pin, and optionally disable its Receiver Enable pin.
 @see ModbusMaster::ModbusMasterTransaction()
 @see ModbusMaster::postTransmission()
 */
-void ModbusMaster::preTransmission(void (*preTransmission)())
+void ModbusMaster::preTransmission(service_fn_t preTransmission)
 {
   _preTransmission = preTransmission;
 }
@@ -211,7 +211,7 @@ Receiver Enable pin, and disable its Driver Enable pin.
 @see ModbusMaster::ModbusMasterTransaction()
 @see ModbusMaster::preTransmission()
 */
-void ModbusMaster::postTransmission(void (*postTransmission)())
+void ModbusMaster::postTransmission(service_fn_t postTransmission)
 {
   _postTransmission = postTransmission;
 }

--- a/src/ModbusMaster.h
+++ b/src/ModbusMaster.h
@@ -49,6 +49,7 @@ Set to 1 to enable debugging features within class:
 /* _____STANDARD INCLUDES____________________________________________________ */
 // include types & constants of Wiring core API
 #include "Arduino.h"
+#include <functional>
 
 /* _____UTILITY MACROS_______________________________________________________ */
 
@@ -69,12 +70,16 @@ RS232/485 (via RTU protocol).
 class ModbusMaster
 {
   public:
+    
+    typedef std::function<void()> service_fn_t;
+
     ModbusMaster();
    
     void begin(uint8_t, Stream &serial);
-    void idle(void (*)());
-    void preTransmission(void (*)());
-    void postTransmission(void (*)());
+
+    void idle(service_fn_t idle_fn);
+    void preTransmission(service_fn_t pre_fn);
+    void postTransmission(service_fn_t post_fn);
 
     // Modbus exception codes
     /**
@@ -255,11 +260,14 @@ class ModbusMaster
     uint8_t ModbusMasterTransaction(uint8_t u8MBFunction);
     
     // idle callback function; gets called during idle time between TX and RX
-    void (*_idle)();
+    service_fn_t _idle;
+    // void (*_idle)();
     // preTransmission callback function; gets called before writing a Modbus message
-    void (*_preTransmission)();
+    service_fn_t _preTransmission;
+    // void (*_preTransmission)();
     // postTransmission callback function; gets called after a Modbus message has been sent
-    void (*_postTransmission)();
+    service_fn_t _postTransmission;
+    // void (*_postTransmission)();
 };
 #endif
 


### PR DESCRIPTION
<!----------------------------------------------------------------------------
Please make sure you've read and understood our contributing guidelines;
https://github.com/4-20ma/ModbusMaster/blob/master/CONTRIBUTING.md

Provide the following information for all issues. Replace [brackets] and placeholder text with your responses.
(QUESTIONS, BUG REPORTS, FEATURE REQUESTS).
-->
### Description
[Describe what this change achieves]

### Issues Resolved
[List any existing issues this PR resolves; include Fixes #xxx or Closes #xxx (where xxx is issue number)]

### Check List

General

- [ ] Code follows coding style defined in STYLE.md
- [ ] Doxygen comments are included inline with code
- [ ] No unnecessary whitespace; check with `git diff --check` before committing.

The following have been modified to reflect new features, if warranted

- [ ] README.md
- [ ] keywords.txt (use tabs as whitespace separators)
- [ ] library.properties
- [ ] examples/ - update or create new ones, as warranted

The following have **NOT** been modified

- [ ] doc/ - will be updated upon versioned release
- [ ] .ruby-gemset
- [ ] .ruby-version
- [ ] CHANGELOG.md - will be updated upon versioned release (HISTORY.md is deprecated)
- [ ] Gemfile
- [ ] LICENSE
- [ ] VERSION - will be updated upon versioned release


**NOTE: use ?w=1 to see the changes and ignore whitespaces**
**https://github.com/4-20ma/ModbusMaster/pull/102/commits/eed84d3f9862b81cde2b28a80f73a05d01a9b7fa?w=1**