### PR TITLE
fixed zero index problem where _u8ResponseBufferLength is set.

### DIFF
--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -837,7 +837,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
             _u16ResponseBuffer[i] = word(u8ModbusADU[2 * i + 4], u8ModbusADU[2 * i + 3]);
           }
           
-          _u8ResponseBufferLength = i;
+          _u8ResponseBufferLength = i + 1;  // i is zero indexed
         }
         
         // in the event of an odd number of bytes, load last byte into zero-padded word
@@ -848,7 +848,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
             _u16ResponseBuffer[i] = word(0, u8ModbusADU[2 * i + 3]);
           }
           
-          _u8ResponseBufferLength = i + 1;
+          _u8ResponseBufferLength = i + 2;  // i is zero indexed
         }
         break;
         
@@ -863,7 +863,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
             _u16ResponseBuffer[i] = word(u8ModbusADU[2 * i + 3], u8ModbusADU[2 * i + 4]);
           }
           
-          _u8ResponseBufferLength = i;
+          _u8ResponseBufferLength = i + 1;  // i is zero indexed
         }
         break;
     }


### PR DESCRIPTION
### Description
when a 1 word (2 byte) response is received _u8ResponseBufferLength is erroneously set to 0 instead of 1
similarly, a 16 word (32 byte) response is received, _u8ResponseBufferLength is set to 15 instead of 16.
This causes available() to return 1 less than it should.

### Issues Resolved
It seems like not many people use the available() function. 

### Check List

General

- [ ] Code follows coding style defined in STYLE.md
- [ ] Doxygen comments are included inline with code
- [ ] No unnecessary whitespace; check with `git diff --check` before committing.

The following have been modified to reflect new features, if warranted

- [ ] README.md
- [ ] keywords.txt (use tabs as whitespace separators)
- [ ] library.properties
- [ ] examples/ - update or create new ones, as warranted

The following have **NOT** been modified

- [ ] doc/ - will be updated upon versioned release
- [ ] .ruby-gemset
- [ ] .ruby-version
- [ ] CHANGELOG.md - will be updated upon versioned release (HISTORY.md is deprecated)
- [ ] Gemfile
- [ ] LICENSE
- [ ] VERSION - will be updated upon versioned release
