### PR TITLE
Create Own Timeout

### DIFF
--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -46,6 +46,7 @@ ModbusMaster::ModbusMaster(void)
   _idle = 0;
   _preTransmission = 0;
   _postTransmission = 0;
+  _u16ResponseTimeout = ku16MBDefaultResponseTimeout;
 }
 
 /**
@@ -134,9 +135,6 @@ void ModbusMaster::send(uint8_t data)
 {
   send(word(data));
 }
-
-
-
 
 
 
@@ -294,6 +292,22 @@ void ModbusMaster::clearTransmitBuffer()
   }
 }
 
+/**
+Get the response timeout.  Value is in msec.
+*/
+uint16_t ModbusMaster::getResponseTimeout()
+{
+   return _u16ResponseTimeout;
+}
+
+/**
+Sets the response timeout.  Value should be given in msec.
+The default is 2000 msec.
+*/
+void ModbusMaster::setResponseTimeout(uint16_t timeout)
+{
+  _u16ResponseTimeout = timeout;
+}
 
 /**
 Modbus function 0x01 Read Coils.
@@ -797,7 +811,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
           break;
       }
     }
-    if ((millis() - u32StartTime) > ku16MBResponseTimeout)
+    if ((millis() - u32StartTime) > _u16ResponseTimeout)
     {
       u8MBStatus = ku8MBResponseTimedOut;
     }

--- a/src/ModbusMaster.h
+++ b/src/ModbusMaster.h
@@ -192,6 +192,9 @@ class ModbusMaster
     void     clearResponseBuffer();
     uint8_t  setTransmitBuffer(uint8_t, uint16_t);
     void     clearTransmitBuffer();
+
+    uint16_t getResponseTimeout();
+    void     setResponseTimeout(uint16_t);
     
     void beginTransmission(uint16_t);
     uint8_t requestFrom(uint16_t, uint16_t);
@@ -233,6 +236,7 @@ class ModbusMaster
     uint16_t* rxBuffer; // from Wire.h -- need to clean this up Rx
     uint8_t _u8ResponseBufferIndex;
     uint8_t _u8ResponseBufferLength;
+    uint16_t _u16ResponseTimeout;
     
     // Modbus function codes for bit access
     static const uint8_t ku8MBReadCoils                  = 0x01; ///< Modbus function 0x01 Read Coils
@@ -249,7 +253,7 @@ class ModbusMaster
     static const uint8_t ku8MBReadWriteMultipleRegisters = 0x17; ///< Modbus function 0x17 Read Write Multiple Registers
     
     // Modbus timeout [milliseconds]
-    static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
+    static const uint16_t ku16MBDefaultResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
     
     // master function that conducts Modbus transactions
     uint8_t ModbusMasterTransaction(uint8_t u8MBFunction);


### PR DESCRIPTION
Added the ability to change the timeout from the default of 2000 msec.

ku16MBResponseTimeout was renamed to ku16MBDefaultTimeout.  The private variable _u16ResponseTimeout was created, along with getResponseTimeout() and setResponseTimeout() methods.

<!----------------------------------------------------------------------------
Please make sure you've read and understood our contributing guidelines;
https://github.com/4-20ma/ModbusMaster/blob/master/CONTRIBUTING.md

Provide the following information for all issues. Replace [brackets] and placeholder text with your responses.
(QUESTIONS, BUG REPORTS, FEATURE REQUESTS).
-->
### Description
[Describe what this change achieves]

### Issues Resolved
[List any existing issues this PR resolves; include Fixes #xxx or Closes #xxx (where xxx is issue number)]

### Check List

General

- [ ] Code follows coding style defined in STYLE.md
- [ ] Doxygen comments are included inline with code
- [ ] No unnecessary whitespace; check with `git diff --check` before committing.

The following have been modified to reflect new features, if warranted

- [ ] README.md
- [ ] keywords.txt (use tabs as whitespace separators)
- [ ] library.properties
- [ ] examples/ - update or create new ones, as warranted

The following have **NOT** been modified

- [ ] doc/ - will be updated upon versioned release
- [ ] .ruby-gemset
- [ ] .ruby-version
- [ ] CHANGELOG.md - will be updated upon versioned release (HISTORY.md is deprecated)
- [ ] Gemfile
- [ ] LICENSE
- [ ] VERSION - will be updated upon versioned release
