### PR TITLE
Change order of CRC high/low bytes

### DIFF
--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -697,8 +697,8 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   {
     u16CRC = crc16_update(u16CRC, u8ModbusADU[i]);
   }
-  u8ModbusADU[u8ModbusADUSize++] = lowByte(u16CRC);
   u8ModbusADU[u8ModbusADUSize++] = highByte(u16CRC);
+  u8ModbusADU[u8ModbusADUSize++] = lowByte(u16CRC);
   u8ModbusADU[u8ModbusADUSize] = 0;
 
   // flush receive buffer before transmitting request


### PR DESCRIPTION
Could you please clarify if the reverse ordering of the checksum bytes is by design? 

I needed to change the order to make the library compatible with my modbus slave which expects all words to be sent using hi/low ordering.