### PR TITLE
Add Modbus function 0x2B/0E Read DeviceIdentifiers, add get/set SlaveID, get/set ResponseTimeout, get .

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -33,6 +33,7 @@ writeMultipleCoils	KEYWORD2
 writeMultipleRegisters	KEYWORD2
 maskWriteRegister	KEYWORD2
 readWriteMultipleRegisters	KEYWORD2
+readDeviceIdentifiers	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=ModbusMaster
-version=2.0.1
-author=Doc Walker
+version=2.0.2
+author=Doc Walker & robl040
 maintainer=Doc Walker <4-20ma@wvfans.net>
 sentence=Enlighten your Arduino to be a Modbus master.
 paragraph=Enables communication with Modbus slaves over RS232/485 (via RTU protocol). Requires an RS232/485 transceiver.

--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -29,9 +29,7 @@ Arduino library for communicating with Modbus slaves over RS232/485 (via RTU pro
 /* _____PROJECT INCLUDES_____________________________________________________ */
 #include "ModbusMaster.h"
 
-
 /* _____GLOBAL VARIABLES_____________________________________________________ */
-
 
 /* _____PUBLIC FUNCTIONS_____________________________________________________ */
 /**
@@ -65,13 +63,12 @@ void ModbusMaster::begin(uint8_t slave, Stream &serial)
   _serial = &serial;
   _u8TransmitBufferIndex = 0;
   u16TransmitBufferLength = 0;
-  
+
 #if __MODBUSMASTER_DEBUG__
   pinMode(__MODBUSMASTER_DEBUG_PIN_A__, OUTPUT);
   pinMode(__MODBUSMASTER_DEBUG_PIN_B__, OUTPUT);
 #endif
 }
-
 
 void ModbusMaster::beginTransmission(uint16_t u16Address)
 {
@@ -96,7 +93,6 @@ uint8_t ModbusMaster::requestFrom(uint16_t address, uint16_t quantity)
   return read;
 }
 
-
 void ModbusMaster::sendBit(bool data)
 {
   uint8_t txBitIndex = u16TransmitBufferLength % 16;
@@ -112,7 +108,6 @@ void ModbusMaster::sendBit(bool data)
   }
 }
 
-
 void ModbusMaster::send(uint16_t data)
 {
   if (_u8TransmitBufferIndex < ku8MaxBufferSize)
@@ -122,32 +117,21 @@ void ModbusMaster::send(uint16_t data)
   }
 }
 
-
 void ModbusMaster::send(uint32_t data)
 {
   send(lowWord(data));
   send(highWord(data));
 }
 
-
 void ModbusMaster::send(uint8_t data)
 {
   send(word(data));
 }
 
-
-
-
-
-
-
-
-
 uint8_t ModbusMaster::available(void)
 {
   return _u8ResponseBufferLength - _u8ResponseBufferIndex;
 }
-
 
 uint16_t ModbusMaster::receive(void)
 {
@@ -160,13 +144,6 @@ uint16_t ModbusMaster::receive(void)
     return 0xFFFF;
   }
 }
-
-
-
-
-
-
-
 
 /**
 Set idle time callback function (cooperative multitasking).
@@ -216,7 +193,6 @@ void ModbusMaster::postTransmission(void (*postTransmission)())
   _postTransmission = postTransmission;
 }
 
-
 /**
 Retrieve data from response buffer.
 
@@ -247,13 +223,12 @@ Clear Modbus response buffer.
 void ModbusMaster::clearResponseBuffer()
 {
   uint8_t i;
-  
+
   for (i = 0; i < ku8MaxBufferSize; i++)
   {
     _u16ResponseBuffer[i] = 0;
   }
 }
-
 
 /**
 Place data in transmit buffer.
@@ -277,7 +252,6 @@ uint8_t ModbusMaster::setTransmitBuffer(uint8_t u8Index, uint16_t u16Value)
   }
 }
 
-
 /**
 Clear Modbus transmit buffer.
 
@@ -287,7 +261,7 @@ Clear Modbus transmit buffer.
 void ModbusMaster::clearTransmitBuffer()
 {
   uint8_t i;
-  
+
   for (i = 0; i < ku8MaxBufferSize; i++)
   {
     _u16TransmitBuffer[i] = 0;
@@ -298,19 +272,19 @@ void ModbusMaster::clearTransmitBuffer()
 /**
 Modbus function 0x01 Read Coils.
 
-This function code is used to read from 1 to 2000 contiguous status of 
-coils in a remote device. The request specifies the starting address, 
-i.e. the address of the first coil specified, and the number of coils. 
+This function code is used to read from 1 to 2000 contiguous status of
+coils in a remote device. The request specifies the starting address,
+i.e. the address of the first coil specified, and the number of coils.
 Coils are addressed starting at zero.
 
-The coils in the response buffer are packed as one coil per bit of the 
-data field. Status is indicated as 1=ON and 0=OFF. The LSB of the first 
-data word contains the output addressed in the query. The other coils 
-follow toward the high order end of this word and from low order to high 
+The coils in the response buffer are packed as one coil per bit of the
+data field. Status is indicated as 1=ON and 0=OFF. The LSB of the first
+data word contains the output addressed in the query. The other coils
+follow toward the high order end of this word and from low order to high
 order in subsequent words.
 
-If the returned quantity is not a multiple of sixteen, the remaining 
-bits in the final data word will be padded with zeros (toward the high 
+If the returned quantity is not a multiple of sixteen, the remaining
+bits in the final data word will be padded with zeros (toward the high
 order end of the word).
 
 @param u16ReadAddress address of first coil (0x0000..0xFFFF)
@@ -325,23 +299,22 @@ uint8_t ModbusMaster::readCoils(uint16_t u16ReadAddress, uint16_t u16BitQty)
   return ModbusMasterTransaction(ku8MBReadCoils);
 }
 
-
 /**
 Modbus function 0x02 Read Discrete Inputs.
 
-This function code is used to read from 1 to 2000 contiguous status of 
-discrete inputs in a remote device. The request specifies the starting 
-address, i.e. the address of the first input specified, and the number 
+This function code is used to read from 1 to 2000 contiguous status of
+discrete inputs in a remote device. The request specifies the starting
+address, i.e. the address of the first input specified, and the number
 of inputs. Discrete inputs are addressed starting at zero.
 
-The discrete inputs in the response buffer are packed as one input per 
-bit of the data field. Status is indicated as 1=ON; 0=OFF. The LSB of 
-the first data word contains the input addressed in the query. The other 
-inputs follow toward the high order end of this word, and from low order 
+The discrete inputs in the response buffer are packed as one input per
+bit of the data field. Status is indicated as 1=ON; 0=OFF. The LSB of
+the first data word contains the input addressed in the query. The other
+inputs follow toward the high order end of this word, and from low order
 to high order in subsequent words.
 
-If the returned quantity is not a multiple of sixteen, the remaining 
-bits in the final data word will be padded with zeros (toward the high 
+If the returned quantity is not a multiple of sixteen, the remaining
+bits in the final data word will be padded with zeros (toward the high
 order end of the word).
 
 @param u16ReadAddress address of first discrete input (0x0000..0xFFFF)
@@ -357,16 +330,15 @@ uint8_t ModbusMaster::readDiscreteInputs(uint16_t u16ReadAddress,
   return ModbusMasterTransaction(ku8MBReadDiscreteInputs);
 }
 
-
 /**
 Modbus function 0x03 Read Holding Registers.
 
-This function code is used to read the contents of a contiguous block of 
-holding registers in a remote device. The request specifies the starting 
-register address and the number of registers. Registers are addressed 
+This function code is used to read the contents of a contiguous block of
+holding registers in a remote device. The request specifies the starting
+register address and the number of registers. Registers are addressed
 starting at zero.
 
-The register data in the response buffer is packed as one word per 
+The register data in the response buffer is packed as one word per
 register.
 
 @param u16ReadAddress address of the first holding register (0x0000..0xFFFF)
@@ -382,16 +354,15 @@ uint8_t ModbusMaster::readHoldingRegisters(uint16_t u16ReadAddress,
   return ModbusMasterTransaction(ku8MBReadHoldingRegisters);
 }
 
-
 /**
 Modbus function 0x04 Read Input Registers.
 
-This function code is used to read from 1 to 125 contiguous input 
-registers in a remote device. The request specifies the starting 
-register address and the number of registers. Registers are addressed 
+This function code is used to read from 1 to 125 contiguous input
+registers in a remote device. The request specifies the starting
+register address and the number of registers. Registers are addressed
 starting at zero.
 
-The register data in the response buffer is packed as one word per 
+The register data in the response buffer is packed as one word per
 register.
 
 @param u16ReadAddress address of the first input register (0x0000..0xFFFF)
@@ -407,14 +378,13 @@ uint8_t ModbusMaster::readInputRegisters(uint16_t u16ReadAddress,
   return ModbusMasterTransaction(ku8MBReadInputRegisters);
 }
 
-
 /**
 Modbus function 0x05 Write Single Coil.
 
-This function code is used to write a single output to either ON or OFF 
-in a remote device. The requested ON/OFF state is specified by a 
-constant in the state field. A non-zero value requests the output to be 
-ON and a value of 0 requests it to be OFF. The request specifies the 
+This function code is used to write a single output to either ON or OFF
+in a remote device. The requested ON/OFF state is specified by a
+constant in the state field. A non-zero value requests the output to be
+ON and a value of 0 requests it to be OFF. The request specifies the
 address of the coil to be forced. Coils are addressed starting at zero.
 
 @param u16WriteAddress address of the coil (0x0000..0xFFFF)
@@ -429,12 +399,11 @@ uint8_t ModbusMaster::writeSingleCoil(uint16_t u16WriteAddress, uint8_t u8State)
   return ModbusMasterTransaction(ku8MBWriteSingleCoil);
 }
 
-
 /**
 Modbus function 0x06 Write Single Register.
 
-This function code is used to write a single holding register in a 
-remote device. The request specifies the address of the register to be 
+This function code is used to write a single holding register in a
+remote device. The request specifies the address of the register to be
 written. Registers are addressed starting at zero.
 
 @param u16WriteAddress address of the holding register (0x0000..0xFFFF)
@@ -451,16 +420,15 @@ uint8_t ModbusMaster::writeSingleRegister(uint16_t u16WriteAddress,
   return ModbusMasterTransaction(ku8MBWriteSingleRegister);
 }
 
-
 /**
 Modbus function 0x0F Write Multiple Coils.
 
-This function code is used to force each coil in a sequence of coils to 
-either ON or OFF in a remote device. The request specifies the coil 
+This function code is used to force each coil in a sequence of coils to
+either ON or OFF in a remote device. The request specifies the coil
 references to be forced. Coils are addressed starting at zero.
 
-The requested ON/OFF states are specified by contents of the transmit 
-buffer. A logical '1' in a bit position of the buffer requests the 
+The requested ON/OFF states are specified by contents of the transmit
+buffer. A logical '1' in a bit position of the buffer requests the
 corresponding output to be ON. A logical '0' requests it to be OFF.
 
 @param u16WriteAddress address of the first coil (0x0000..0xFFFF)
@@ -481,14 +449,13 @@ uint8_t ModbusMaster::writeMultipleCoils()
   return ModbusMasterTransaction(ku8MBWriteMultipleCoils);
 }
 
-
 /**
 Modbus function 0x10 Write Multiple Registers.
 
-This function code is used to write a block of contiguous registers (1 
+This function code is used to write a block of contiguous registers (1
 to 123 registers) in a remote device.
 
-The requested written values are specified in the transmit buffer. Data 
+The requested written values are specified in the transmit buffer. Data
 is packed as one word per register.
 
 @param u16WriteAddress address of the holding register (0x0000..0xFFFF)
@@ -511,17 +478,16 @@ uint8_t ModbusMaster::writeMultipleRegisters()
   return ModbusMasterTransaction(ku8MBWriteMultipleRegisters);
 }
 
-
 /**
 Modbus function 0x16 Mask Write Register.
 
-This function code is used to modify the contents of a specified holding 
-register using a combination of an AND mask, an OR mask, and the 
-register's current contents. The function can be used to set or clear 
+This function code is used to modify the contents of a specified holding
+register using a combination of an AND mask, an OR mask, and the
+register's current contents. The function can be used to set or clear
 individual bits in the register.
 
-The request specifies the holding register to be written, the data to be 
-used as the AND mask, and the data to be used as the OR mask. Registers 
+The request specifies the holding register to be written, the data to be
+used as the AND mask, and the data to be used as the OR mask. Registers
 are addressed starting at zero.
 
 The function's algorithm is:
@@ -543,18 +509,17 @@ uint8_t ModbusMaster::maskWriteRegister(uint16_t u16WriteAddress,
   return ModbusMasterTransaction(ku8MBMaskWriteRegister);
 }
 
-
 /**
 Modbus function 0x17 Read Write Multiple Registers.
 
-This function code performs a combination of one read operation and one 
-write operation in a single MODBUS transaction. The write operation is 
-performed before the read. Holding registers are addressed starting at 
+This function code performs a combination of one read operation and one
+write operation in a single MODBUS transaction. The write operation is
+performed before the read. Holding registers are addressed starting at
 zero.
 
-The request specifies the starting address and number of holding 
-registers to be read as well as the starting address, and the number of 
-holding registers. The data to be written is specified in the transmit 
+The request specifies the starting address and number of holding
+registers to be read as well as the starting address, and the number of
+holding registers. The data to be written is specified in the transmit
 buffer.
 
 @param u16ReadAddress address of the first holding register (0x0000..0xFFFF)
@@ -606,11 +571,11 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   uint32_t u32StartTime;
   uint8_t u8BytesLeft = 8;
   uint8_t u8MBStatus = ku8MBSuccess;
-  
+
   // assemble Modbus Request Application Data Unit
   u8ModbusADU[u8ModbusADUSize++] = _u8MBSlave;
   u8ModbusADU[u8ModbusADUSize++] = u8MBFunction;
-  
+
   switch(u8MBFunction)
   {
     case ku8MBReadCoils:
@@ -624,7 +589,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16ReadQty);
       break;
   }
-  
+
   switch(u8MBFunction)
   {
     case ku8MBWriteSingleCoil:
@@ -637,19 +602,19 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16WriteAddress);
       break;
   }
-  
+
   switch(u8MBFunction)
   {
     case ku8MBWriteSingleCoil:
       u8ModbusADU[u8ModbusADUSize++] = highByte(_u16WriteQty);
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16WriteQty);
       break;
-      
+
     case ku8MBWriteSingleRegister:
       u8ModbusADU[u8ModbusADUSize++] = highByte(_u16TransmitBuffer[0]);
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16TransmitBuffer[0]);
       break;
-      
+
     case ku8MBWriteMultipleCoils:
       u8ModbusADU[u8ModbusADUSize++] = highByte(_u16WriteQty);
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16WriteQty);
@@ -662,27 +627,27 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
           case 0: // i is even
             u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16TransmitBuffer[i >> 1]);
             break;
-            
+
           case 1: // i is odd
             u8ModbusADU[u8ModbusADUSize++] = highByte(_u16TransmitBuffer[i >> 1]);
             break;
         }
       }
       break;
-      
+
     case ku8MBWriteMultipleRegisters:
     case ku8MBReadWriteMultipleRegisters:
       u8ModbusADU[u8ModbusADUSize++] = highByte(_u16WriteQty);
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16WriteQty);
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16WriteQty << 1);
-      
+
       for (i = 0; i < lowByte(_u16WriteQty); i++)
       {
         u8ModbusADU[u8ModbusADUSize++] = highByte(_u16TransmitBuffer[i]);
         u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16TransmitBuffer[i]);
       }
       break;
-      
+
     case ku8MBMaskWriteRegister:
       u8ModbusADU[u8ModbusADUSize++] = highByte(_u16TransmitBuffer[0]);
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16TransmitBuffer[0]);
@@ -690,7 +655,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
       u8ModbusADU[u8ModbusADUSize++] = lowByte(_u16TransmitBuffer[1]);
       break;
   }
-  
+
   // append CRC
   u16CRC = 0xFFFF;
   for (i = 0; i < u8ModbusADUSize; i++)
@@ -713,14 +678,14 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   {
     _serial->write(u8ModbusADU[i]);
   }
-  
+
   u8ModbusADUSize = 0;
   _serial->flush();    // flush transmit buffer
   if (_postTransmission)
   {
     _postTransmission();
   }
-  
+
   // loop until we run out of time or bytes, or an error occurs
   u32StartTime = millis();
   while (u8BytesLeft && !u8MBStatus)
@@ -749,7 +714,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
       digitalWrite(__MODBUSMASTER_DEBUG_PIN_B__, false);
 #endif
     }
-    
+
     // evaluate slave ID, function code once enough bytes have been read
     if (u8ModbusADUSize == 5)
     {
@@ -759,21 +724,21 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
         u8MBStatus = ku8MBInvalidSlaveID;
         break;
       }
-      
+
       // verify response is for correct Modbus function code (mask exception bit 7)
       if ((u8ModbusADU[1] & 0x7F) != u8MBFunction)
       {
         u8MBStatus = ku8MBInvalidFunction;
         break;
       }
-      
+
       // check whether Modbus exception occurred; return Modbus Exception Code
       if (bitRead(u8ModbusADU[1], 7))
       {
         u8MBStatus = u8ModbusADU[2];
         break;
       }
-      
+
       // evaluate returned Modbus function code
       switch(u8ModbusADU[1])
       {
@@ -784,14 +749,14 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
         case ku8MBReadWriteMultipleRegisters:
           u8BytesLeft = u8ModbusADU[2];
           break;
-          
+
         case ku8MBWriteSingleCoil:
         case ku8MBWriteMultipleCoils:
         case ku8MBWriteSingleRegister:
         case ku8MBWriteMultipleRegisters:
           u8BytesLeft = 3;
           break;
-          
+
         case ku8MBMaskWriteRegister:
           u8BytesLeft = 5;
           break;
@@ -802,7 +767,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
       u8MBStatus = ku8MBResponseTimedOut;
     }
   }
-  
+
   // verify response is large enough to inspect further
   if (!u8MBStatus && u8ModbusADUSize >= 5)
   {
@@ -812,7 +777,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
     {
       u16CRC = crc16_update(u16CRC, u8ModbusADU[i]);
     }
-    
+
     // verify CRC
     if (!u8MBStatus && (lowByte(u16CRC) != u8ModbusADU[u8ModbusADUSize - 2] ||
       highByte(u16CRC) != u8ModbusADU[u8ModbusADUSize - 1]))
@@ -836,10 +801,10 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
           {
             _u16ResponseBuffer[i] = word(u8ModbusADU[2 * i + 4], u8ModbusADU[2 * i + 3]);
           }
-          
+
           _u8ResponseBufferLength = i;
         }
-        
+
         // in the event of an odd number of bytes, load last byte into zero-padded word
         if (u8ModbusADU[2] % 2)
         {
@@ -847,11 +812,11 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
           {
             _u16ResponseBuffer[i] = word(0, u8ModbusADU[2 * i + 3]);
           }
-          
+
           _u8ResponseBufferLength = i + 1;
         }
         break;
-        
+
       case ku8MBReadInputRegisters:
       case ku8MBReadHoldingRegisters:
       case ku8MBReadWriteMultipleRegisters:
@@ -862,13 +827,13 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
           {
             _u16ResponseBuffer[i] = word(u8ModbusADU[2 * i + 3], u8ModbusADU[2 * i + 4]);
           }
-          
+
           _u8ResponseBufferLength = i;
         }
         break;
     }
   }
-  
+
   _u8TransmitBufferIndex = 0;
   u16TransmitBufferLength = 0;
   _u8ResponseBufferIndex = 0;

--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -24,7 +24,9 @@ Arduino library for communicating with Modbus slaves over RS232/485 (via RTU pro
   limitations under the License.
 
 */
-
+//uncomment for DEBUG
+//#define DEBUG_SEND_MESSAGE
+//#define DEBUG_RECEIVED_MESSAGE
 
 /* _____PROJECT INCLUDES_____________________________________________________ */
 #include "ModbusMaster.h"
@@ -58,7 +60,6 @@ Call once class has been instantiated, typically within setup().
 */
 void ModbusMaster::begin(uint8_t slave, Stream &serial)
 {
-//  txBuffer = (uint16_t*) calloc(ku8MaxBufferSize, sizeof(uint16_t));
   _u8MBSlave = slave;
   _serial = &serial;
   _u8TransmitBufferIndex = 0;
@@ -78,20 +79,20 @@ void ModbusMaster::beginTransmission(uint16_t u16Address)
 }
 
 // eliminate this function in favor of using existing MB request functions
-uint8_t ModbusMaster::requestFrom(uint16_t address, uint16_t quantity)
-{
-  uint8_t read;
-  // clamp to buffer length
-  if (quantity > ku8MaxBufferSize)
-  {
-    quantity = ku8MaxBufferSize;
-  }
-  // set rx buffer iterator vars
-  _u8ResponseBufferIndex = 0;
-  _u8ResponseBufferLength = read;
-
-  return read;
-}
+//uint8_t ModbusMaster::requestFrom(uint16_t address, uint16_t quantity)
+//{
+//  uint8_t read;
+//  // clamp to buffer length
+//  if (quantity > ku8MaxBufferSize)
+//  {
+//    quantity = ku8MaxBufferSize;
+//  }
+//  // set rx buffer iterator vars
+//  _u8ResponseBufferIndex = 0;
+//  _u8ResponseBufferLength = read;
+//
+//  return read;
+//}
 
 void ModbusMaster::sendBit(bool data)
 {
@@ -371,7 +372,7 @@ register.
 @ingroup register
 */
 uint8_t ModbusMaster::readInputRegisters(uint16_t u16ReadAddress,
-  uint8_t u16ReadQty)
+  uint16_t u16ReadQty)
 {
   _u16ReadAddress = u16ReadAddress;
   _u16ReadQty = u16ReadQty;

--- a/src/ModbusMaster.h
+++ b/src/ModbusMaster.h
@@ -269,10 +269,8 @@ class ModbusMaster
     uint16_t _u16WriteAddress;                                   ///< slave register to which to write
     uint16_t _u16WriteQty;                                       ///< quantity of words to write
     uint16_t _u16TransmitBuffer[ku8MaxBufferSize];               ///< buffer containing data to transmit to Modbus slave; set via SetTransmitBuffer()
-    //uint16_t* txBuffer; // from Wire.h -- need to clean this up Rx
     uint8_t _u8TransmitBufferIndex;
     uint16_t u16TransmitBufferLength;
-    //uint16_t* rxBuffer; // from Wire.h -- need to clean this up Rx
     uint8_t _u8ResponseBufferIndex;
     uint8_t _u8ResponseBufferLength;
 

--- a/src/ModbusMaster.h
+++ b/src/ModbusMaster.h
@@ -31,10 +31,8 @@ Arduino library for communicating with Modbus slaves over RS232/485 (via RTU pro
 
 */
 
-  
 #ifndef ModbusMaster_h
 #define ModbusMaster_h
-
 
 /**
 @def __MODBUSMASTER_DEBUG__ (0)
@@ -52,7 +50,6 @@ Set to 1 to enable debugging features within class:
 
 /* _____UTILITY MACROS_______________________________________________________ */
 
-
 /* _____PROJECT INCLUDES_____________________________________________________ */
 // functions to calculate Modbus Application Data Unit CRC
 #include "util/crc16.h"
@@ -63,14 +60,14 @@ Set to 1 to enable debugging features within class:
 
 /* _____CLASS DEFINITIONS____________________________________________________ */
 /**
-Arduino class library for communicating with Modbus slaves over 
+Arduino class library for communicating with Modbus slaves over
 RS232/485 (via RTU protocol).
 */
 class ModbusMaster
 {
   public:
     ModbusMaster();
-   
+
     void begin(uint8_t, Stream &serial);
     void idle(void (*)());
     void preTransmission(void (*)());
@@ -79,59 +76,59 @@ class ModbusMaster
     // Modbus exception codes
     /**
     Modbus protocol illegal function exception.
-    
+
     The function code received in the query is not an allowable action for
     the server (or slave). This may be because the function code is only
     applicable to newer devices, and was not implemented in the unit
     selected. It could also indicate that the server (or slave) is in the
     wrong state to process a request of this type, for example because it is
     unconfigured and is being asked to return register values.
-    
+
     @ingroup constant
     */
     static const uint8_t ku8MBIllegalFunction            = 0x01;
 
     /**
     Modbus protocol illegal data address exception.
-    
-    The data address received in the query is not an allowable address for 
-    the server (or slave). More specifically, the combination of reference 
-    number and transfer length is invalid. For a controller with 100 
-    registers, the ADU addresses the first register as 0, and the last one 
-    as 99. If a request is submitted with a starting register address of 96 
-    and a quantity of registers of 4, then this request will successfully 
-    operate (address-wise at least) on registers 96, 97, 98, 99. If a 
-    request is submitted with a starting register address of 96 and a 
-    quantity of registers of 5, then this request will fail with Exception 
-    Code 0x02 "Illegal Data Address" since it attempts to operate on 
-    registers 96, 97, 98, 99 and 100, and there is no register with address 
-    100. 
-    
+
+    The data address received in the query is not an allowable address for
+    the server (or slave). More specifically, the combination of reference
+    number and transfer length is invalid. For a controller with 100
+    registers, the ADU addresses the first register as 0, and the last one
+    as 99. If a request is submitted with a starting register address of 96
+    and a quantity of registers of 4, then this request will successfully
+    operate (address-wise at least) on registers 96, 97, 98, 99. If a
+    request is submitted with a starting register address of 96 and a
+    quantity of registers of 5, then this request will fail with Exception
+    Code 0x02 "Illegal Data Address" since it attempts to operate on
+    registers 96, 97, 98, 99 and 100, and there is no register with address
+    100.
+
     @ingroup constant
     */
     static const uint8_t ku8MBIllegalDataAddress         = 0x02;
-    
+
     /**
     Modbus protocol illegal data value exception.
-    
-    A value contained in the query data field is not an allowable value for 
-    server (or slave). This indicates a fault in the structure of the 
-    remainder of a complex request, such as that the implied length is 
-    incorrect. It specifically does NOT mean that a data item submitted for 
-    storage in a register has a value outside the expectation of the 
-    application program, since the MODBUS protocol is unaware of the 
+
+    A value contained in the query data field is not an allowable value for
+    server (or slave). This indicates a fault in the structure of the
+    remainder of a complex request, such as that the implied length is
+    incorrect. It specifically does NOT mean that a data item submitted for
+    storage in a register has a value outside the expectation of the
+    application program, since the MODBUS protocol is unaware of the
     significance of any particular value of any particular register.
-    
+
     @ingroup constant
     */
     static const uint8_t ku8MBIllegalDataValue           = 0x03;
-    
+
     /**
     Modbus protocol slave device failure exception.
-    
+
     An unrecoverable error occurred while the server (or slave) was
     attempting to perform the requested action.
-    
+
     @ingroup constant
     */
     static const uint8_t ku8MBSlaveDeviceFailure         = 0x04;
@@ -139,60 +136,60 @@ class ModbusMaster
     // Class-defined success/exception codes
     /**
     ModbusMaster success.
-    
+
     Modbus transaction was successful; the following checks were valid:
       - slave ID
       - function code
       - response code
       - data
       - CRC
-      
+
     @ingroup constant
     */
     static const uint8_t ku8MBSuccess                    = 0x00;
-    
+
     /**
     ModbusMaster invalid response slave ID exception.
-    
+
     The slave ID in the response does not match that of the request.
-    
+
     @ingroup constant
     */
     static const uint8_t ku8MBInvalidSlaveID             = 0xE0;
-    
+
     /**
     ModbusMaster invalid response function exception.
-    
+
     The function code in the response does not match that of the request.
-    
+
     @ingroup constant
     */
     static const uint8_t ku8MBInvalidFunction            = 0xE1;
-    
+
     /**
     ModbusMaster response timed out exception.
-    
-    The entire response was not received within the timeout period, 
-    ModbusMaster::ku8MBResponseTimeout. 
-    
+
+    The entire response was not received within the timeout period,
+    ModbusMaster::ku8MBResponseTimeout.
+
     @ingroup constant
     */
     static const uint8_t ku8MBResponseTimedOut           = 0xE2;
-    
+
     /**
     ModbusMaster invalid response CRC exception.
-    
+
     The CRC in the response does not match the one calculated.
-    
+
     @ingroup constant
     */
     static const uint8_t ku8MBInvalidCRC                 = 0xE3;
-    
+
     uint16_t getResponseBuffer(uint8_t);
     void     clearResponseBuffer();
     uint8_t  setTransmitBuffer(uint8_t, uint16_t);
     void     clearTransmitBuffer();
-    
+
     void beginTransmission(uint16_t);
     uint8_t requestFrom(uint16_t, uint16_t);
     void sendBit(bool);
@@ -201,8 +198,7 @@ class ModbusMaster
     void send(uint32_t);
     uint8_t available(void);
     uint16_t receive(void);
-    
-    
+
     uint8_t  readCoils(uint16_t, uint16_t);
     uint8_t  readDiscreteInputs(uint16_t, uint16_t);
     uint8_t  readHoldingRegisters(uint16_t, uint16_t);
@@ -216,11 +212,11 @@ class ModbusMaster
     uint8_t  maskWriteRegister(uint16_t, uint16_t, uint16_t);
     uint8_t  readWriteMultipleRegisters(uint16_t, uint16_t, uint16_t, uint16_t);
     uint8_t  readWriteMultipleRegisters(uint16_t, uint16_t);
-    
+
   private:
     Stream* _serial;                                             ///< reference to serial port object
     uint8_t  _u8MBSlave;                                         ///< Modbus slave (1..255) initialized in begin()
-    static const uint8_t ku8MaxBufferSize                = 64;   ///< size of response/transmit buffers    
+    static const uint8_t ku8MaxBufferSize                = 64;   ///< size of response/transmit buffers
     uint16_t _u16ReadAddress;                                    ///< slave register from which to read
     uint16_t _u16ReadQty;                                        ///< quantity of words to read
     uint16_t _u16ResponseBuffer[ku8MaxBufferSize];               ///< buffer to store Modbus slave response; read via GetResponseBuffer()
@@ -233,7 +229,7 @@ class ModbusMaster
     uint16_t* rxBuffer; // from Wire.h -- need to clean this up Rx
     uint8_t _u8ResponseBufferIndex;
     uint8_t _u8ResponseBufferLength;
-    
+
     // Modbus function codes for bit access
     static const uint8_t ku8MBReadCoils                  = 0x01; ///< Modbus function 0x01 Read Coils
     static const uint8_t ku8MBReadDiscreteInputs         = 0x02; ///< Modbus function 0x02 Read Discrete Inputs
@@ -247,13 +243,13 @@ class ModbusMaster
     static const uint8_t ku8MBWriteMultipleRegisters     = 0x10; ///< Modbus function 0x10 Write Multiple Registers
     static const uint8_t ku8MBMaskWriteRegister          = 0x16; ///< Modbus function 0x16 Mask Write Register
     static const uint8_t ku8MBReadWriteMultipleRegisters = 0x17; ///< Modbus function 0x17 Read Write Multiple Registers
-    
+
     // Modbus timeout [milliseconds]
     static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
-    
+
     // master function that conducts Modbus transactions
     uint8_t ModbusMasterTransaction(uint8_t u8MBFunction);
-    
+
     // idle callback function; gets called during idle time between TX and RX
     void (*_idle)();
     // preTransmission callback function; gets called before writing a Modbus message

--- a/src/ModbusMaster.h
+++ b/src/ModbusMaster.h
@@ -232,9 +232,14 @@ class ModbusMaster
     static const uint8_t ku8MBInvalidCRC                 = 0xE3;
 
     uint16_t getResponseBuffer(uint8_t Index);
+    uint8_t getResponseSize(void);
     void clearResponseBuffer(void);
     uint8_t setTransmitBuffer(uint8_t Offset, uint16_t Value);
     void clearTransmitBuffer(void);
+    void setSlaveId(uint8_t slaveid);
+    uint8_t getSlaveId(void);
+    uint16_t getResponseTimeout(void);
+    void setResponseTimeout(uint16_t timeout_ms);
 
     void beginTransmission(uint16_t u16Address);
     //uint8_t requestFrom(uint16_t Addr, uint16_t Qty);
@@ -258,6 +263,8 @@ class ModbusMaster
     uint8_t maskWriteRegister(uint16_t u16WriteAddress, uint16_t u16AndMask, uint16_t u16OrMask);
     uint8_t readWriteMultipleRegisters(uint16_t u16ReadAddress, uint16_t u16ReadQty, uint16_t u16WriteAddress, uint16_t u16WriteQty);
     uint8_t readWriteMultipleRegisters(uint16_t Addr, uint16_t Qty);
+    //uint8_t  readDeviceIdentifiers(uint8_t ReadId, uint8_t ObjectId);
+    uint8_t readDeviceIdentifiers(uint8_t ReadId, uint8_t ObjectId, char *pu8ReadStrBuffer, uint8_t u8ReadStrBufferMaxSize, uint8_t *pu8ReadStrSize);
 
   private:
     Stream* _serial;                                             ///< reference to serial port object
@@ -273,6 +280,10 @@ class ModbusMaster
     uint16_t u16TransmitBufferLength;
     uint8_t _u8ResponseBufferIndex;
     uint8_t _u8ResponseBufferLength;
+    char *_pu8ReadStrBuffer;
+    uint8_t _u8ReadStrBufferMaxSize;
+    uint8_t *_pu8ReadStrSize;
+    uint16_t _u16ResponseTimeout;
 
     // Modbus function codes for bit access
     static const uint8_t ku8MBReadCoils                  = 0x01; ///< Modbus function 0x01 Read Coils
@@ -288,8 +299,10 @@ class ModbusMaster
     static const uint8_t ku8MBMaskWriteRegister          = 0x16; ///< Modbus function 0x16 Mask Write Register
     static const uint8_t ku8MBReadWriteMultipleRegisters = 0x17; ///< Modbus function 0x17 Read Write Multiple Registers
 
+    static const uint8_t ku8MBReadDeviceIdentifiers = 0x2B;      ///< Modbus function 0x2B/0E Read DeviceIdentifiers
+
     // Modbus timeout [milliseconds]
-    static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
+    static const uint16_t ku16MBDefaultResponseTimeout   = 2000; ///< Modbus timeout [milliseconds]
 
     // master function that conducts Modbus transactions
     uint8_t ModbusMasterTransaction(uint8_t u8MBFunction);


### PR DESCRIPTION
Add method to change/request (get/set) the SlaveID.
Add method to change/request (get/set) the ResponseTimeout.
Add method to request the response size of data in the response buffer.
Add Modbus function 0x2B/0E Read DeviceIdentifiers ku8MBReadDeviceIdentifiers.

<!----------------------------------------------------------------------------
Please make sure you've read and understood our contributing guidelines;
https://github.com/4-20ma/ModbusMaster/blob/master/CONTRIBUTING.md

Provide the following information for all issues. Replace [brackets] and placeholder text with your responses.
(QUESTIONS, BUG REPORTS, FEATURE REQUESTS).
-->
### Description
Several issues multiple users reported about are resolved

### Issues Resolved

#183 Changing Slave ID
#182 ReadHoldingRegisters takes 2seconds
#144 BUG REPORT: does not compile with -Werror=uninitialized due to bug in ModbusMaster::requestFrom(...) ==> requestFrom method has been removed.
#135  removed set slave id function 
#124 Set own timeout?

### Check List

General

- [ ] Code follows coding style defined in STYLE.md
- [ ] Doxygen comments are included inline with code
- [x] No unnecessary whitespace; check with `git diff --check` before committing.
   -> trailing whitespace removed as separate commit ac851324f91e517c198fbc3dca4b12a4495c97ef


The following have been modified to reflect new features, if warranted

- [ ] README.md
- [ ] keywords.txt (use tabs as whitespace separators)
- [ ] library.properties
- [ ] examples/ - update or create new ones, as warranted

The following have **NOT** been modified

- [ ] doc/ - will be updated upon versioned release
- [ ] .ruby-gemset
- [ ] .ruby-version
- [ ] CHANGELOG.md - will be updated upon versioned release (HISTORY.md is deprecated)
- [ ] Gemfile
- [ ] LICENSE
- [ ] VERSION - will be updated upon versioned release
