### PR TITLE
Patch 2

### DIFF
--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -229,11 +229,11 @@ void ModbusMaster::preTransmission() {
 }
 
 /**
-Function extends the preTransmission functionality, and we can now
+Function extends the postTransmission functionality, and we can now
 inherit the class and override this method.
 
 @see ModbusMaster::ModbusMasterTransaction()
-@see ModbusMaster::preTransmission()
+@see ModbusMaster::postTransmission()
 */
 void ModbusMaster::postTransmission() {
 	if (_postTransmission)

--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -216,6 +216,29 @@ void ModbusMaster::postTransmission(void (*postTransmission)())
   _postTransmission = postTransmission;
 }
 
+/**
+Function extends the preTransmission functionality, and we can now
+inherit the class and override this method.
+
+@see ModbusMaster::ModbusMasterTransaction()
+@see ModbusMaster::preTransmission()
+*/
+void ModbusMaster::preTransmission() {
+	if (_preTransmission)
+		_preTransmission();
+}
+
+/**
+Function extends the preTransmission functionality, and we can now
+inherit the class and override this method.
+
+@see ModbusMaster::ModbusMasterTransaction()
+@see ModbusMaster::preTransmission()
+*/
+void ModbusMaster::postTransmission() {
+	if (_postTransmission)
+		_postTransmission();
+}
 
 /**
 Retrieve data from response buffer.
@@ -705,10 +728,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   while (_serial->read() != -1);
 
   // transmit request
-  if (_preTransmission)
-  {
-    _preTransmission();
-  }
+  preTransmission();
   for (i = 0; i < u8ModbusADUSize; i++)
   {
     _serial->write(u8ModbusADU[i]);
@@ -716,10 +736,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
   
   u8ModbusADUSize = 0;
   _serial->flush();    // flush transmit buffer
-  if (_postTransmission)
-  {
-    _postTransmission();
-  }
+  postTransmission();
   
   // loop until we run out of time or bytes, or an error occurs
   u32StartTime = millis();

--- a/src/ModbusMaster.h
+++ b/src/ModbusMaster.h
@@ -75,6 +75,8 @@ class ModbusMaster
     void idle(void (*)());
     void preTransmission(void (*)());
     void postTransmission(void (*)());
+    virtual void preTransmission();
+    virtual void postTransmission();
 
     // Modbus exception codes
     /**


### PR DESCRIPTION
<!----------------------------------------------------------------------------
Please make sure you've read and understood our contributing guidelines;
https://github.com/4-20ma/ModbusMaster/blob/master/CONTRIBUTING.md

Provide the following information for all issues. Replace [brackets] and placeholder text with your responses.
(QUESTIONS, BUG REPORTS, FEATURE REQUESTS).
-->
### Description
I created a class which inherits and extends the current functionality, so that now I can do this:

    void preTransmission() override {
        digitalWrite(mEnablePin, HIGH); // Enable Modbus communication
    }
    void postTransmission() override {
        digitalWrite(mEnablePin, LOW); // Disable Modbus communication
    }

Where "mEnablePin" is passed as part of the constructor.

In the current implementation, I tried to implement a solution to use different Enable pins in different instantiated objects, but then I must set static functions externally to the class.

### Issues Resolved
With this modification, I now can encapsulate the functionality to my inherited class.
